### PR TITLE
Implement patch-like mimicking with import strings

### DIFF
--- a/.github/workflows/all_checks_pass.yml
+++ b/.github/workflows/all_checks_pass.yml
@@ -1,0 +1,10 @@
+name: All checks pass
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wechuli/allcheckspassed@v1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import pytest_mimic
 
 def test_function_to_test():
     # Wrap the expensive function in a mimic context manager
-    with pytest_mimic.mimic(expensive_function):
+    with pytest_mimic.mimic('module.expensive_function'):
        result = function_to_test()  # This function calls expensive_function internally
     assert result == expected_value
 ```
@@ -61,9 +61,9 @@ Configure functions to be mimicked globally in your project configuration:
 # pyproject.toml
 [tool.pytest.ini_options]
 mimic_functions = [
-    "some_module:expensive_function",
-    "some_module:another_function",
-    "some_module.sub_module:SomeClass.method"
+    "some_module.expensive_function",
+    "some_module.another_function",
+    "some_module.sub_module.SomeClass.method"
 ]
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,9 +60,9 @@ A list of functions to mimic globally (without needing to use the context manage
 ```toml
 [tool.pytest.ini_options]
 mimic_functions = [
-    "some_module:expensive_function",
-    "some_module:another_function",
-    "some_module.sub_module:SomeClass.method"
+    "some_module.expensive_function",
+    "some_module.another_function",
+    "some_module.sub_module.SomeClass.method"
 ]
 ```
 
@@ -71,9 +71,9 @@ mimic_functions = [
 ```ini
 [pytest]
 mimic_functions =
-    some_module:expensive_function
-    some_module:another_function
-    some_module.sub_module:SomeClass.method
+    some_module.expensive_function
+    some_module.another_function
+    some_module.sub_module.SomeClass.method
 ```
 
 ### mimic_vault_path

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -31,7 +31,7 @@ from api import get_user_data, process_user_data
 
 def test_process_user_data():
     # Mimic the API call function
-    with pytest_mimic.mimic(get_user_data):
+    with pytest_mimic.mimic('api.get_user_data'):
         result = process_user_data(user_id=123)
     
     # Assert on the processed result
@@ -73,7 +73,7 @@ from database import get_active_users, count_active_users
 
 def test_count_active_users():
     # Mimic the database query function
-    with pytest_mimic.mimic(get_active_users):
+    with pytest_mimic.mimic('database.get_active_users'):
         count = count_active_users()
     
     # Assert on the count
@@ -115,7 +115,7 @@ from async_api import fetch_data, process_multiple_endpoints
 @pytest.mark.asyncio
 async def test_process_multiple_endpoints():
     # Mimic the async fetch function
-    with pytest_mimic.mimic(fetch_data):
+    with pytest_mimic.mimic('async_api.fetch_data'):
         results = await process_multiple_endpoints()
     
     # Assert on the results
@@ -156,7 +156,7 @@ from data_processor import DataProcessor
 
 def test_process():
     # Mimic the class method
-    with pytest_mimic.mimic(DataProcessor.normalize_data):
+    with pytest_mimic.mimic('data_processor.DataProcessor.normalize_data'):
         processor = DataProcessor()
         result = processor.process({"Name": "John Doe ", "AGE": 30})
     
@@ -173,9 +173,9 @@ Using the global configuration to mimic functions:
 # pyproject.toml
 [tool.pytest.ini_options]
 mimic_functions = [
-    "myapp.api:get_user_data",
-    "myapp.database:get_active_users",
-    "myapp.data_processor:DataProcessor.normalize_data"
+    "myapp.api.get_user_data",
+    "myapp.database.get_active_users",
+    "myapp.data_processor.DataProcessor.normalize_data"
 ]
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ import pytest_mimic
 
 def test_function_to_test():
     # Wrap the expensive function in a mimic context manager
-    with pytest_mimic.mimic(expensive_function):
+    with pytest_mimic.mimic('module.sub_module.expensive_function'):
        result = function_to_test()  # This function calls expensive_function internally
     assert result == expected_value
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ Wrap expensive function calls with the `mimic` context manager in your test:
 import pytest_mimic
 
 def test_my_function():
-    with pytest_mimic.mimic(expensive_function):
+    with pytest_mimic.mimic('module.sub_module.expensive_function'):
         result = function_that_calls_expensive_function()
     assert result == expected_result
 ```
@@ -52,9 +52,9 @@ Instead of adding the mimic context manager to each test, you can configure func
 ```toml
 [tool.pytest.ini_options]
 mimic_functions = [
-    "some_module:expensive_function",
-    "some_module:another_function", 
-    "some_module.sub_module:SomeClass.method"
+    "some_module.expensive_function",
+    "some_module.another_function", 
+    "some_module.sub_module.SomeClass.method"
 ]
 # Optional: specify custom location for mimic cache directory
 # mimic_vault_path = ".mimic_vault"
@@ -65,9 +65,9 @@ mimic_functions = [
 ```ini
 [pytest]
 mimic_functions =
-    some_module:expensive_function
-    some_module:another_function
-    some_module.sub_module:SomeClass.method
+    some_module.expensive_function
+    some_module.another_function
+    some_module.sub_module.SomeClass.method
 # Optional: specify custom location for mimic vault
 # mimic_vault_path = .mimic_vault
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-mimic"
 description = "Easily record function calls while testing"
-version = "0.1.2"
+version = "0.2.0"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [
@@ -58,7 +58,7 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"
 mimic_functions = [
-    "tests.example_module:example_function_to_mimic"
+    "tests.example_module.example_function_to_mimic"
 ]
 # Optional: specify custom location for mimic cache directory
 # mimic_vault_path = ".mimic_vault"

--- a/src/pytest_mimic/plugin.py
+++ b/src/pytest_mimic/plugin.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("pytest_mimic")
 
 def pytest_addoption(parser):
     """Add pytest-mimic command line options and configuration settings.
-    
+
     Args:
         parser: The pytest command line parser
     """
@@ -35,7 +35,7 @@ def pytest_addoption(parser):
     parser.addini(
         "mimic_functions",
         type="linelist",
-        help="List of functions to mimic (in format: module.submodule:function_name)",
+        help="List of functions to mimic (in format: module.submodule.function_name)",
         default=[],
     )
 
@@ -47,10 +47,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """Configure pytest-mimic based on command-line options and ini settings.
-    
+
     This function sets up the environment variables that control mimic behavior
     and initializes the mimic system.
-    
+
     Args:
         config: The pytest configuration object
     """
@@ -76,14 +76,14 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     """Clean up after all tests have run.
-    
+
     This function handles checking for unused recordings and optionally:
     1. Fails the test run if unused recordings are found and --mimic-fail-on-unused is set
     2. Removes unused recordings if --mimic-clear-unused is set
-    
+
     Args:
         config: The pytest configuration object
-        
+
     Raises:
         RuntimeError: If unused recordings are found and --mimic-fail-on-unused is set
     """

--- a/tests/test_mimic.py
+++ b/tests/test_mimic.py
@@ -26,14 +26,14 @@ def test_mimic_across_runs(pytester):
 
         @pytest.mark.asyncio
         async def test_mimic_async_func():
-            with mimic(async_func_to_mimic):
+            with mimic('test_mimic_across_runs.async_func_to_mimic'):
 
                 result = await async_func_to_mimic(5, b=3)
 
             assert result['result'] == 8
 
         def test_mimic_sync_func():
-            with mimic(sync_func_to_mimic):
+            with mimic('test_mimic_across_runs.sync_func_to_mimic'):
 
                 result = sync_func_to_mimic(5, b=3)
 

--- a/tests/test_mimic_class_methods.py
+++ b/tests/test_mimic_class_methods.py
@@ -6,17 +6,15 @@ from pytest_mimic.mimic_manager import mimic
 from tests.example_module import ExampleClass
 
 
-def test_mimic_fails_on_instance_methods():
+def test_mimic_fails_on_non_string_paths():
     obj = ExampleClass()
-    with pytest.raises(
-        ValueError, match="It is not possible to mimic methods of instantiated objects"
-    ):
+    with pytest.raises(ImportError, match="Failed to import function from path"):
         with mimic(obj.example_method):
             obj.example_method(5, b=3)
 
 
 def test_mimic_classmethod():
-    with mimic(ExampleClass.example_classmethod):
+    with mimic("tests.example_module.ExampleClass.example_classmethod"):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass.example_classmethod(5, b=3)
         # Set record mode
@@ -29,7 +27,7 @@ def test_mimic_classmethod():
 
 
 def test_mimic_staticmethod():
-    with mimic(ExampleClass.example_staticmethod):
+    with mimic("tests.example_module.ExampleClass.example_staticmethod"):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass.example_staticmethod(5, b=3)
         # Set record mode
@@ -42,7 +40,7 @@ def test_mimic_staticmethod():
 
 
 def test_mimic_instance_method():
-    with mimic(ExampleClass.example_method):
+    with mimic("tests.example_module.ExampleClass.example_method"):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass().example_method(5, b=3)
         # Set record mode
@@ -56,13 +54,15 @@ def test_mimic_instance_method():
 
 def test_mimic_mutable_method():
     os.environ["MIMIC_RECORD"] = "1"
-    with mimic(ExampleClass.example_mutable_method):
+    with mimic("tests.example_module.ExampleClass.example_mutable_method"):
         with pytest.raises(RuntimeError, match="has mutated its inputs."):
             ExampleClass().example_mutable_method(5, b=3)
 
 
 def test_mimic_nested_classmethod():
-    with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_class):
+    with mimic(
+        "tests.example_module.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_class"
+    ):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass.NestedClass.DoubleNestedClass.example_dnested_class(5, b=3)
         # Set record mode
@@ -75,7 +75,9 @@ def test_mimic_nested_classmethod():
 
 
 def test_mimic_nested_staticmethod():
-    with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod):
+    with mimic(
+        "tests.example_module.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod"
+    ):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod(5, b=3)
         # Set record mode
@@ -91,7 +93,9 @@ def test_mimic_nested_staticmethod():
 
 
 def test_mimic_nested_instance_method():
-    with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_method):
+    with mimic(
+        "tests.example_module.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_method"
+    ):
         with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function call"):
             ExampleClass.NestedClass.DoubleNestedClass().example_dnested_method(5, b=3)
         # Set record mode
@@ -118,7 +122,7 @@ def test_mimic_class_methods_works(pytester):
     """
     )
     pytester.makepyfile(
-        """
+        test_file="""
         import pytest
         from src.pytest_mimic.mimic_manager import mimic
 
@@ -158,39 +162,45 @@ def test_mimic_class_methods_works(pytester):
                         return self.instance_value + a + b
 
         def test_mimic_classmethod():
-            with mimic(ExampleClass.example_classmethod):
+            with mimic('test_file.ExampleClass.example_classmethod'):
                 result = ExampleClass.example_classmethod(5, b=3)
             assert result == 8
 
         def test_mimic_staticmethod():
-            with mimic(ExampleClass.example_staticmethod):
+            with mimic('test_file.ExampleClass.example_staticmethod'):
                 result = ExampleClass.example_staticmethod(5, b=3)
             assert result == 8
 
         def test_mimic_instance_method():
-            with mimic(ExampleClass.example_method):
+            with mimic('test_file.ExampleClass.example_method'):
                 result = ExampleClass().example_method(5, b=3)
             assert result == 8
 
         def test_mimic_mutable_method():
-            with mimic(ExampleClass.example_mutable_method):
+            with mimic('test_file.ExampleClass.example_mutable_method'):
                 with pytest.raises(RuntimeError, match="has mutated its inputs."):
                     ExampleClass().example_mutable_method(5, b=3)
 
         def test_mimic_nested_classmethod():
-            with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_classmethod):
+            with mimic(
+                'test_file.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_classmethod'
+            ):
                 result = ExampleClass.NestedClass.DoubleNestedClass.example_dnested_classmethod(
                     5, b=3)
             assert result == 8
 
         def test_mimic_nested_staticmethod():
-            with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod):
+            with mimic(
+                'test_file.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod'
+            ):
                 result = ExampleClass.NestedClass.DoubleNestedClass.example_dnested_staticmethod(
                     5, b=3)
             assert result == 8
 
         def test_mimic_nested_instance_method():
-            with mimic(ExampleClass.NestedClass.DoubleNestedClass.example_dnested_method):
+            with mimic(
+                'test_file.ExampleClass.NestedClass.DoubleNestedClass.example_dnested_method'
+            ):
                 result = ExampleClass.NestedClass.DoubleNestedClass().example_dnested_method(5, b=3)
             assert result == 8
         """

--- a/tests/test_mimic_manager.py
+++ b/tests/test_mimic_manager.py
@@ -32,7 +32,7 @@ class TestMimicManager:
         cache_files = list(tmp_mimic_vault.glob("**/*.pkl"))
         assert len(cache_files) == 0
 
-        with mimic(async_dummy_func):
+        with mimic("test_mimic_manager.async_dummy_func"):
             result = await async_dummy_func(5, b=3)
 
         # Verify result
@@ -48,7 +48,7 @@ class TestMimicManager:
         # Set record mode for initial recording
         os.environ["MIMIC_RECORD"] = "1"
 
-        with mimic(async_dummy_func):
+        with mimic("test_mimic_manager.async_dummy_func"):
             result = await async_dummy_func(5, b=3)
 
             # Switch to replay mode
@@ -63,7 +63,7 @@ class TestMimicManager:
         """Test that an exception is raised if no mock is found in replay mode."""
         os.environ["MIMIC_RECORD"] = "0"
 
-        with mimic(async_dummy_func):
+        with mimic("test_mimic_manager.async_dummy_func"):
             # Call with args that haven't been recorded should fail
             with pytest.raises(RuntimeError, match="Missing mimic-recorded result for function"):
                 await async_dummy_func(999)
@@ -94,8 +94,8 @@ class TestMimicManager:
         # Set record mode and create files in the vault
         os.environ["MIMIC_RECORD"] = "1"
 
-        with mimic(async_dummy_func):
-            with mimic(sync_dummy_func):
+        with mimic("test_mimic_manager.async_dummy_func"):
+            with mimic("test_mimic_manager.sync_dummy_func"):
                 sync_dummy_func(5, b=3)
                 sync_dummy_func(5, b=4)
                 await async_dummy_func(0, 1)
@@ -118,8 +118,8 @@ class TestMimicManager:
         os.environ["MIMIC_RECORD"] = "1"
 
         # Patch and call the functions to create recordings
-        with mimic(async_dummy_func):
-            with mimic(sync_dummy_func):
+        with mimic("test_mimic_manager.async_dummy_func"):
+            with mimic("test_mimic_manager.sync_dummy_func"):
                 # Record function calls with different args
                 sync_dummy_func(5, b=3)
                 sync_dummy_func(10, b=20)
@@ -141,7 +141,7 @@ class TestMimicManager:
         os.environ["MIMIC_RECORD"] = "1"
 
         # Patch the sync function
-        with mimic(sync_dummy_func):
+        with mimic("test_mimic_manager.sync_dummy_func"):
             # First call to record
             result = sync_dummy_func(5, b=3)
             assert result == {"result": 8}

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ envlist = py39,py310,py311,py312,py313,pypy3,ruff
 [testenv]
 runner = uv-venv-lock-runner
 deps = pytest>=6.2.0
-extras =
-    dev
 commands =
     pytest {posargs:tests} --random-order --mimic-fail-on-unused
     ruff check

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
@@ -77,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "pytest-mimic"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pytest" },


### PR DESCRIPTION
- Overhauls mimic context manager to utilize import path strings instead of actual python callables for improved robustness and ease of use
- Simplifies string structure for import path to match mock.patch approach